### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/blaneczka9599/b18680ae-05b4-420c-a72c-50d37edddc07/49994edb-dce0-4e4f-b259-99baa9fa6b77/_apis/work/boardbadge/ce74e38d-4520-4e3a-9583-fbca6f8543b6)](https://dev.azure.com/blaneczka9599/b18680ae-05b4-420c-a72c-50d37edddc07/_boards/board/t/49994edb-dce0-4e4f-b259-99baa9fa6b77/Microsoft.RequirementCategory)
 # Dawid-
 sowa9599@gmail.com


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/blaneczka9599/b18680ae-05b4-420c-a72c-50d37edddc07/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.